### PR TITLE
update reference to clinical trial matching service library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1026,7 +1026,7 @@
     },
     "node_modules/clinical-trial-matching-service": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#ecdeddd8e632dffed6131f0adaf54cfdb68da46a",
+      "resolved": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#dd55127e11eeed17020ebcd6f0afe4baf81246f2",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",
@@ -1680,7 +1680,11 @@
         "lodash",
         "path",
         "q",
-        "xml-js"
+        "xml-js",
+        "inherits",
+        "process",
+        "sax",
+        "util"
       ],
       "dev": true,
       "dependencies": {
@@ -4736,7 +4740,7 @@
       "dev": true
     },
     "clinical-trial-matching-service": {
-      "version": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#ecdeddd8e632dffed6131f0adaf54cfdb68da46a",
+      "version": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#dd55127e11eeed17020ebcd6f0afe4baf81246f2",
       "from": "clinical-trial-matching-service@github:mcode/clinical-trial-matching-service",
       "requires": {
         "body-parser": "^1.19.0",


### PR DESCRIPTION
Pull requests into the clinical-trial-matching-service-template require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [x]	Does an update need to be made to the documentation with these changes? No
- [x]	Does an update need to be made to the service wrappers as well? Already updated
- [x]	Does an update need to be made to the service library? N/A
- [x] Was the new feature tested by unit tests? N/A
- [x] Was the new feature tested by a manual, end-to-end test? N/A
