### PR TITLE
Update reference to matching service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "clinical-trial-matching-service": "github:mcode/clinical-trial-matching-service",
+        "clinical-trial-matching-service": "^0.0.2",
         "dotenv-flow": "^3.2.0"
       },
       "devDependencies": {
@@ -1025,8 +1025,9 @@
       }
     },
     "node_modules/clinical-trial-matching-service": {
-      "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#2a3598ff9d089bbc3f748106154659b3576efffd",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/clinical-trial-matching-service/-/clinical-trial-matching-service-0.0.2.tgz",
+      "integrity": "sha512-KIfQUVdHN9PgjefAGzxXubRMhRWMxKubEOWvBgrSv5yJAkEzLylSfPWD6k3sUKzWsdWkk3tBALhIv30g3ccvMA==",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",
@@ -1600,7 +1601,6 @@
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dependencies": {
-        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -4741,8 +4741,9 @@
       "dev": true
     },
     "clinical-trial-matching-service": {
-      "version": "git+ssh://git@github.com/mcode/clinical-trial-matching-service.git#2a3598ff9d089bbc3f748106154659b3576efffd",
-      "from": "clinical-trial-matching-service@github:mcode/clinical-trial-matching-service",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/clinical-trial-matching-service/-/clinical-trial-matching-service-0.0.2.tgz",
+      "integrity": "sha512-KIfQUVdHN9PgjefAGzxXubRMhRWMxKubEOWvBgrSv5yJAkEzLylSfPWD6k3sUKzWsdWkk3tBALhIv30g3ccvMA==",
       "requires": {
         "body-parser": "^1.19.0",
         "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "clinical-trial-matching-service": "github:mcode/clinical-trial-matching-service",
+    "clinical-trial-matching-service": "^0.0.2",
     "dotenv-flow": "^3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Pull requests into the clinical-trial-matching-service-template require the following. Submitter should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] Make sure test coverage didn’t decrease. If you are allowing the test coverage to drop, leave an explanation as to why:
- [ ]	Does an update need to be made to the documentation with these changes?
- [ ]	Does an update need to be made to the service wrappers as well?
- [ ]	Does an update need to be made to the service library?
- [ ] Was the new feature tested by unit tests?
- [ ] Was the new feature tested by a manual, end-to-end test?
